### PR TITLE
HG34: speed up report display generation

### DIFF
--- a/src/headline_grabber/pipeline_steps/prepare_for_display.py
+++ b/src/headline_grabber/pipeline_steps/prepare_for_display.py
@@ -30,8 +30,8 @@ class PrepareForDisplay(PipelineStep):
                     " ".join([headline.title, headline.description])
                     for headline in headlines
                 ],
-                min_length=150,
-                max_length=250,
+                min_length=50,
+                max_length=200,
             )
             subjects = sorted(
                 list(set([headline.subject.label for headline in headlines]))
@@ -82,17 +82,17 @@ class PrepareForDisplay(PipelineStep):
         inputs = text_summarization_tokenizer(
             texts,
             return_tensors="pt",
-            max_length=1024,
+            max_length=256,
             truncation=True,
             padding="max_length",
         )
         summary_ids = text_summarization_model.generate(
             inputs["input_ids"],
-            num_beams=4,
-            length_penalty=2.0,
+            num_beams=2,
             max_length=max_length,
             min_length=min_length,
             early_stopping=True,
+            length_penalty=10.0
         )
         summary = text_summarization_tokenizer.decode(
             summary_ids[0], skip_special_tokens=True
@@ -108,8 +108,9 @@ class PrepareForDisplay(PipelineStep):
             input_ids=input_ids,
             attention_mask=attention_masks,
             max_length=64,
-            num_beams=3,
-            early_stopping=True,
+            num_beams=1,
+            early_stopping=False,
+            length_penalty=None
         )
         result = headline_tokenizer.decode(beam_outputs[0])
         result = result.replace("<pad> ", "").replace("</s>", "")


### PR DESCRIPTION
Changes result in about a 70% speed boost in the prepare for display step.

BEFORE:
![image](https://github.com/user-attachments/assets/d72a440c-d32f-4e72-853b-385df54cdfb2)


AFTER:

![image](https://github.com/user-attachments/assets/a6e2396e-f258-4a60-992f-9f1f049737b3)

Report content as a result is also more concise and a bit cleaner to read:

![image](https://github.com/user-attachments/assets/af299724-8f71-4a25-a672-c5d1edb8b85d)

Versus:

![image](https://github.com/user-attachments/assets/df25a6c1-2ea4-4f6e-a19a-6eeecf04bbee)
