### PR TITLE
HG31 - Add display report unit test cases

### DIFF
--- a/tests/headline_grabber/pipeline_steps/display_report_test.py
+++ b/tests/headline_grabber/pipeline_steps/display_report_test.py
@@ -1,0 +1,59 @@
+import os
+import shutil
+
+from datetime import datetime
+from headline_grabber.pipeline_steps.display_report import DisplayReport
+from tests.headline_grabber.pipeline_steps.test_data.display_report_data import DisplayReportData
+
+def test_build_export_path():
+    target_dir = None
+    result = DisplayReport.build_export_path(target_dir)
+    assert result == os.path.join(os.getcwd(), "reports")
+    shutil.rmtree(result, ignore_errors=True)
+
+    target_dir = "/Users/n3t/Documents/COSC540/report0720"
+    result = DisplayReport.build_export_path(target_dir)
+    assert result == target_dir
+    shutil.rmtree(result, ignore_errors=True)
+
+def test_build_html_file_path():
+    target_dir = None
+    assert "news_report_" in DisplayReport.build_html_file_path(target_dir)
+
+    target_dir = "/Users/n3t/Documents/COSC540/report0720"
+    assert "/Users/n3t/Documents/COSC540/report0720/news_report_" in DisplayReport.build_html_file_path(target_dir)
+
+def test_build_html_content():
+    context = DisplayReportData.GOOD_CONTEXT
+    html_report = DisplayReport().build_html_content(context)
+    assert "<title>Dominate your HTML</title>" in html_report
+    assert "<h1>Headline Grabber Report</h1>" in html_report
+    assert "<h2>World</h2>" in html_report
+    assert "<h4>Braverman claims leadership rival Jenrick is from left of Tory party</h4>" in html_report
+    assert "<span>Positive (0.1)</span>" in html_report
+    assert '<a href="https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn">https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn</a>' in html_report
+
+def test_display_report_fail():
+    target_dir = "/Users/n3t/Documents/COSC540/report0720"
+    os.makedirs(target_dir, exist_ok=True)
+    assert DisplayReport._display_report(DisplayReportData.HTML_CONTENT, target_dir) == False
+    shutil.rmtree(target_dir, ignore_errors=True)
+
+def test_display_report_success():
+    formatted_datetime = datetime.now().strftime("%Y-%m-%d_%H_%M")
+    report_path = "/Users/n3t/Documents/COSC540/report0720"
+    os.makedirs(report_path, exist_ok=True)
+    report_name = f"/news_report_{formatted_datetime}.html"
+    assert DisplayReport._display_report(DisplayReportData.HTML_CONTENT, report_path + report_name) == True
+    shutil.rmtree(report_path, ignore_errors=True)
+
+def test_run_success():
+    context = DisplayReportData.GOOD_CONTEXT
+    DisplayReport().run(context)
+    report_path = context.user_input.target_dir
+    assert len(os.listdir(report_path)) > 0
+    shutil.rmtree(report_path, ignore_errors=True)
+
+def test_sanitize_html_content():
+    html_content = "<h4>Braverman claims — ”leadership rival” Jenrick‘ is from left of Tory party</h4>"
+    assert DisplayReport.sanitize_html_content(html_content) == "<h4>Braverman claims - \"leadership rival\" Jenrick' is from left of Tory party</h4>"  

--- a/tests/headline_grabber/pipeline_steps/scrape_text_test.py
+++ b/tests/headline_grabber/pipeline_steps/scrape_text_test.py
@@ -6,9 +6,7 @@ from headline_grabber.models.news_site import *
 from headline_grabber.models.pipeline_context import PipelineContext
 from headline_grabber.models.user_preferences import UserPreferences
 from headline_grabber.pipeline_steps.scrape_text import ScrapeText, ScrapeTextException
-from tests.headline_grabber.pipeline_steps.test_data.scrape_text_data import (
-    ScrapeTextData,
-)
+from tests.headline_grabber.pipeline_steps.test_data.scrape_text_data import ScrapeTextData
 
 
 def test_get_headlines_nyt_beautifulsoup():
@@ -39,18 +37,9 @@ def test_parse_headline_reu():
         config.selectors.headline.tag, class_=config.selectors.headline.identifier
     )[0]
     actualResult = scrape_text._parse_headline(headline, config.selectors, config.url)
-    assert (
-        actualResult.title.strip()
-        == "Trump's running mate J.D. Vance to take spotlight, as Biden contracts COVID"
-    )
-    assert (
-        actualResult.description.strip()
-        == "Donald Trump's vice presidential running mate, U.S. Senator J.D. Vance, addresses the Republican National Convention on Wednesday in a speech that could illustrate how Trump's \"Make America Great Again\" movement may dominate the party for years to come."
-    )
-    assert (
-        actualResult.link.strip()
-        == "https://www.reuters.com/world/us/trump-lauded-by-former-rivals-haley-desantis-show-unity-republican-convention-2024-07-17/"
-    )
+    assert actualResult.title.strip() == "Trump's running mate J.D. Vance to take spotlight, as Biden contracts COVID"
+    assert actualResult.description.strip() == "Donald Trump's vice presidential running mate, U.S. Senator J.D. Vance, addresses the Republican National Convention on Wednesday in a speech that could illustrate how Trump's \"Make America Great Again\" movement may dominate the party for years to come."
+    assert actualResult.link.strip() == "https://www.reuters.com/world/us/trump-lauded-by-former-rivals-haley-desantis-show-unity-republican-convention-2024-07-17/"
 
 
 def test_parse_headline_tol():
@@ -63,21 +52,12 @@ def test_parse_headline_tol():
         config.selectors.headline.tag, class_=config.selectors.headline.identifier
     )[0]
     actualResult = scrape_text._parse_headline(headline, config.selectors, config.url)
-    assert (
-        actualResult.title.strip()
-        == "Braverman claims leadership rival Jenrick is from left of Tory party"
-    )
-    assert (
-        actualResult.description.strip()
-        == "Suella Braverman has accused Robert Jenrick of being a “centrist Rishi supporter” who is “from the left of the party”, after one of her key supporters switched to backing the former immigration minister. Jenrick and Braverman, the former home secretary, are among seven of the remaining 121 Tory MPs preparing to stand for the leadership..."
-    )
-    assert (
-        actualResult.link.strip()
-        == "https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn"
-    )
+    assert actualResult.title.strip() == "Braverman claims leadership rival Jenrick is from left of Tory party"
+    assert actualResult.description.strip() == 'Suella Braverman has accused Robert Jenrick of being a “centrist Rishi supporter” who is “from the left of the party”, after one of her key supporters switched to backing the former immigration minister. Jenrick and Braverman, the former home secretary, are among seven of the remaining 121 Tory MPs preparing to stand for the leadership...'
+    assert actualResult.link.strip() == "https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn"
 
 
-def test_run_TOL_Success():
+def test_run_tol_success():
     scrape_text = ScrapeText()
     config = ScrapeTextData.TOL_CONFIG
     pipeline_context = PipelineContext(
@@ -94,7 +74,7 @@ def test_run_TOL_Success():
     assert len(actualResult.headlines) > 0
 
 
-def test_run_REU_Success():
+def test_run_reu_success():
     scrape_text = ScrapeText()
     config = ScrapeTextData.REU_CONFIG
     pipeline_context = PipelineContext(
@@ -139,25 +119,17 @@ def test_parse_headline_nyt():
     with open("tests/headline_grabber/pipeline_steps/test_data/nyt.html", "r") as file:
         html = file.read()
     soup = BeautifulSoup(html, "html.parser")
-    headline = soup.find_all(
-        config.selectors.headline.tag, class_=config.selectors.headline.identifier
-    )[0]
+    headline = soup.find_all(config.selectors.headline.tag, class_=config.selectors.headline.identifier)[0]
     actualResult = scrape_text._parse_headline(headline, config.selectors, config.url)
-    assert (
-        actualResult.description.strip()
-        == "President Biden's conversations are the first indication that he is seriously considering whether he can recover after a devastating debate performance."
-    )
-    assert (
-        actualResult.title.strip()
-        == "Biden Tells Allies He Knows He Has Only Days to Salvage Candidacy"
-    )
-    assert (
-        actualResult.link.strip()
-        == "https://www.nytimes.com/2024/07/03/us/politics/biden-withdraw-election-debate.html"
-    )
+    assert actualResult.description.strip() == ("President Biden's conversations are the first indication that he is "
+                                                "seriously considering whether he can recover after a devastating "
+                                                "debate performance.")
+    assert actualResult.title.strip() == 'Biden Tells Allies He Knows He Has Only Days to Salvage Candidacy'
+    assert actualResult.link.strip() == ('https://www.nytimes.com/2024/07/03/us/politics/biden-withdraw-election'
+                                         '-debate.html')
 
 
-def test_filter_results_False():
+def test_filter_results_false():
     scrape_text = ScrapeText()
     link = "https://www.nytimes.com/2024/07/03/us/politics/biden-withdraw-election-debate.html"
     description = "hello"
@@ -175,7 +147,7 @@ def test_filter_results_False():
     assert scrape_text._filter_results(headline) is False
 
 
-def test_filter_results_True():
+def test_filter_results_true():
     scrape_text = ScrapeText()
     link = "https://www.nytimes.com/2024/07/03/us/politics/biden-withdraw-election-debate.html"
     description = "President Biden's conversations are the first indication that he is seriously considering whether he can recover after a devastating debate performance."
@@ -184,7 +156,7 @@ def test_filter_results_True():
     assert scrape_text._filter_results(headline) is True
 
 
-def test_run_Exception():
+def test_run_exception():
     scrape_text = ScrapeText()
     config = ScrapeTextData.ERROR_CONFIG
     pipeline_context = PipelineContext(
@@ -202,7 +174,7 @@ def test_run_Exception():
     assert "No headlines found." in str(exceptionInfo)
 
 
-def test_run_Success():
+def test_run_success():
     scrape_text = ScrapeText()
     config = ScrapeTextData.NYT_CONFIG
     pipeline_context = PipelineContext(
@@ -215,5 +187,5 @@ def test_run_Success():
             exclude=None,
         ),
     )
-    actualResult = scrape_text.run(pipeline_context)
-    assert len(actualResult.headlines) > 0
+    actual_result = scrape_text.run(pipeline_context)
+    assert len(actual_result.headlines) > 0

--- a/tests/headline_grabber/pipeline_steps/test_data/display_report_data.py
+++ b/tests/headline_grabber/pipeline_steps/test_data/display_report_data.py
@@ -1,0 +1,79 @@
+
+from headline_grabber.models.display_document import DisplayDocument
+from headline_grabber.models.headline import Classification
+from headline_grabber.models.pipeline_context import PipelineContext
+from headline_grabber.models.user_preferences import UserPreferences
+
+
+class DisplayReportData:
+
+    GOOD_CONTEXT = PipelineContext(
+        site_configs=[],
+        headlines=[],
+        grouped_headlines={},
+        documents_for_display={
+            "World": [
+                DisplayDocument(
+                    links=[
+                        "https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn",
+                    ],
+                    summarized_title="Braverman claims leadership rival Jenrick is from left of Tory party",
+                    summarized_description='Suella Braverman has accused Robert Jenrick of being a "centrist Rishi supporter" who is "from the left of the party", after one of her key supporters switched to backing the former immigration minister. Jenrick and Braverman, the former home secretary, are among seven of the remaining 121 Tory MPs preparing to stand for the leadership...',
+                    average_sentiment=Classification("Positive", 0.1),
+                    subjects=[
+                        "First Subject",
+                    ],
+                    most_common_subject="World"
+                )
+            ]
+        },
+        user_input=UserPreferences(
+            include="nyt",
+            exclude=None,
+            target_dir="/Users/n3t/Documents/COSC540/report0720",
+            limit=None,
+        )
+    )
+
+    HTML_CONTENT = r'''
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Dominate your HTML</title>
+            <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+            <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.min.js" type="text/javascript"></script>
+        </head>
+        <body>
+            <div class="container">
+            <div class="row">
+                <div class="col-12">
+                <h1>Headline Grabber Report</h1>
+                <div class="fst-italic">
+                    <p>Generated At: 2024-07-21_23_01</p>
+                    <p>This report contains content from the following news sources: </p>
+                </div>
+                </div>
+            </div>
+            <div class="row">
+                <h2>World</h2>
+                <div class="col-6">
+                <h4>Braverman claims leadership rival Jenrick is from left of Tory party</h4>
+                <p>Suella Braverman has accused Robert Jenrick of being a “centrist Rishi supporter” who is “from the left of the party”, after one of her key supporters switched to backing the former immigration minister. Jenrick and Braverman, the former home secretary, are among seven of the remaining 121 Tory MPs preparing to stand for the leadership...</p>
+                <b>Sentiment:
+                    <span>Positive (0.1)</span>
+                </b>
+                <p>
+                    <b>Sources:</b>
+                </p>
+                <ol>
+                    <li>
+                    <a href="https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn">https://www.thetimes.com/uk/politics/article/suella-braverman-tory-leadership-race-robert-jenrick-rivals-mnghlk9fn</a>
+                    </li>
+                </ol>
+                </div>
+                <hr>
+            </div>
+            </div>
+        </body>
+        </html>
+    '''


### PR DESCRIPTION
**HG31 - Add display report unit test cases**

Changes in this PR
- Update display_report.py: using static method for some functions
- Add unit test for display_report.py
- Update some function name for scrap_text_test.

Class display_report.py now has 100% code coverage.
All unit test passed.
[unit_test_report.pdf](https://github.com/user-attachments/files/16328154/unit_test_report.pdf)

